### PR TITLE
11am Edge Case fix

### DIFF
--- a/Services/RawDataToClientData/RawDataToClientData/Function.cs
+++ b/Services/RawDataToClientData/RawDataToClientData/Function.cs
@@ -14,8 +14,16 @@ namespace RawDataToClientData
     {
         public async Task FunctionHandler(DynamoDBEvent dynamoEvent)
         {
-            var cameras = await CameraRepository.GetCameras();
-            
+            var date = DateTime.UtcNow;
+            var cameras = await CameraRepository.GetCamerasByDate(date);
+
+            if (cameras.Count == 0)
+            {
+                Console.WriteLine($"No Cameras found for {date}");
+                Console.WriteLine($"Checking previous day for cameras");
+                cameras = await CameraRepository.GetCamerasByDate(date.AddDays(-1));
+            }
+
             Console.WriteLine("Camera count: " + cameras.Count);
 
             foreach (var record in dynamoEvent.Records)

--- a/Services/RawDataToClientData/RawDataToClientData/Repositories/CameraRepository.cs
+++ b/Services/RawDataToClientData/RawDataToClientData/Repositories/CameraRepository.cs
@@ -11,12 +11,37 @@ namespace RawDataToClientData.Repositories
     {
         private static readonly AmazonDynamoDBClient client = new AmazonDynamoDBClient();
 
+
+        public static async Task<Dictionary<string, string>> GetCamerasByDate(DateTime date)
+        {
+            var cameraQuery = CreateCameraQueryByDate(date);
+            var response = await client.QueryAsync(cameraQuery);
+            return ParseCamerasResponse(response);
+        }
+
+        private static QueryRequest CreateCameraQueryByDate(DateTime date)
+        {
+            var formattedDateToPrimaryKey = $"{date.Month}/{date.Day}/{date.Year.ToString().Substring(2)}";
+            return new QueryRequest
+            {
+                TableName = "CameraImageUrls",
+                KeyConditionExpression = "#date = :date",
+                ExpressionAttributeNames = new Dictionary<string, string> { { "#date", "Date" } },
+                ExpressionAttributeValues = new Dictionary<string, AttributeValue> { { ":date", new AttributeValue { S = formattedDateToPrimaryKey } } },
+                ScanIndexForward = false,
+                Limit = 10 //TODO: make this handle any number of drone cameras
+            };
+        }
+
+        [Obsolete("Use GetCamerasByDate instead")]
         public static async Task<Dictionary<string, string>> GetCameras()
         {
             var cameraQuery = CreateCameraQuery();
             var response = await client.QueryAsync(cameraQuery);
             return ParseCamerasResponse(response);
         }
+
+        [Obsolete("Use CreateCameraQueryByDate instead")]
         private static QueryRequest CreateCameraQuery()
         {
             var date = DateTime.UtcNow;

--- a/Services/RawDataToClientData/RawDataToClientData/Repositories/CameraRepository.cs
+++ b/Services/RawDataToClientData/RawDataToClientData/Repositories/CameraRepository.cs
@@ -11,7 +11,6 @@ namespace RawDataToClientData.Repositories
     {
         private static readonly AmazonDynamoDBClient client = new AmazonDynamoDBClient();
 
-
         public static async Task<Dictionary<string, string>> GetCamerasByDate(DateTime date)
         {
             var cameraQuery = CreateCameraQueryByDate(date);


### PR DESCRIPTION
# Resolves https://github.com/ocius/api/issues/41
---
## **Changes:**
### RawDataToClientData (Un-deployed)
* Addresses the 11am edge case by fetching the latest images from the previous day's partition if no images from the current day's partition can be found in the DynamoDB table.
* CreateCameraQuery and GetCameras are superseded by new methods CreateCameraQueryByDate and GetCamerasByDate respectively. This allows for the querying of images from a specific date.